### PR TITLE
improve build.sh to use /bin/sh and pass shellcheck.net

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -1,19 +1,22 @@
-#!/bin/bash
+#!/bin/sh
 
-HOST=$1
+set -e
 
 tar -xf gmp-6.2.0.tar.xz
 cd gmp-6.2.0
 
-[[ $3 = "false" ]] && SHARED_LIBRARY_ARG="--disable-shared"
+if [ "$3" = "false" ]; then
+    SHARED_LIBRARY_ARG="--disable-shared"
+fi
 
 ac_cv_func_obstack_vprintf=no \
 ac_cv_func_localeconv=no \
-./configure --host=$1 CC=cc CFLAGS="$2 -Wl,--unresolved-symbols=ignore-in-object-files" $SHARED_LIBRARY_ARG
+./configure --host="$1" CC=cc CFLAGS="$2 -Wl,--unresolved-symbols=ignore-in-object-files" $SHARED_LIBRARY_ARG
 
 make -j8 CFLAGS="$2"
 
 cp gmp.h ..
 cp .libs/libgmp.a ..
-[[ $3 = "true" ]] && cp .libs/libgmp.so ../dllgmp.so
-
+if [ "$3" = "true" ]; then
+    cp .libs/libgmp.so ../dllgmp.so
+fi


### PR DESCRIPTION
hey,

- I enabled OCaml-CI on this repository
- I tried it on my FreeBSD laptop

Turns out, `/bin/bash` is not available there, but the `build.sh` didn't use many bash extensions -- so I migrated it to use `/bin/sh` (and had https://shellcheck.net validate it). Please give it a try :)