### PR TITLE
Fix build script for non-dynlink targets.

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -19,4 +19,6 @@ cp gmp.h ..
 cp .libs/libgmp.a ..
 if [ "$3" = "true" ]; then
     cp .libs/libgmp.so ../dllgmp.so
+else
+    touch ../dllgmp.so
 fi


### PR DESCRIPTION
When dynlink is not supported, the `dllgmp.so` file is not required, but it's present as a constant in rules targets. Therefore the script has to create a dummy shared file so that dune doesn't complain that a (non-required) target is not built.