### PR TITLE
Do not hardcode jobs

### DIFF
--- a/gmp.opam
+++ b/gmp.opam
@@ -1,17 +1,18 @@
 opam-version: "2.0"
 maintainer: "Lucas Pluvinage <lucas@tarides.com>"
-license:      ["LGPL-3.0-only" "LGPL-2.0-only"]
+license: ["LGPL-3.0-only" "LGPL-2.0-only"]
 authors: "Torbjörn Granlund and contributors"
 homepage: "https://github.com/mirage/ocaml-gmp"
 bug-reports: "https://github.com/mirage/ocaml-gmp/issues"
 dev-repo: "git+https://github.com/mirage/ocaml-gmp.git"
+substs: [ "src/build.sh" ]
 build: [
  [ "dune" "build" "-p" name "-j" jobs ]
- [ "dune" "runtest" {with-test} ]
+ [ "dune" "runtest" "-p" name "-j" jobs {with-test} ]
 ]
 depends: [
-  "ocaml" {>="4.05.0"}
-  "dune" {>="2.6"}
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "2.6"}
   "conf-m4"
 ]
 synopsis: "The GNU Multiple Precision Arithmetic Library"

--- a/src/build.sh.in
+++ b/src/build.sh.in
@@ -13,7 +13,7 @@ ac_cv_func_obstack_vprintf=no \
 ac_cv_func_localeconv=no \
 ./configure --host="$1" CC=cc CFLAGS="$2 -Wl,--unresolved-symbols=ignore-in-object-files" $SHARED_LIBRARY_ARG
 
-make -j8 CFLAGS="$2"
+make -j%{jobs}% CFLAGS="$2"
 
 cp gmp.h ..
 cp .libs/libgmp.a ..

--- a/src/dune
+++ b/src/dune
@@ -8,7 +8,7 @@
 
 (rule
  (targets gmp.h libgmp.a dllgmp.so)
- (deps gmp-6.2.1.tar.xz)
+ (deps gmp-6.2.1.tar.xz build.sh)
  (action
   (run sh ./build.sh %{ocaml-config:host} "%{ocaml-config:ocamlc_cflags}"
     %{ocaml-config:supports_shared_libraries})))

--- a/src/dune
+++ b/src/dune
@@ -10,5 +10,12 @@
  (targets gmp.h libgmp.a dllgmp.so)
  (deps gmp-6.2.1.tar.xz)
  (action
-  (run ./build.sh %{ocaml-config:host} "%{ocaml-config:ocamlc_cflags}"
+  (run sh ./build.sh %{ocaml-config:host} "%{ocaml-config:ocamlc_cflags}"
     %{ocaml-config:supports_shared_libraries})))
+
+(rule
+ (targets build.sh)
+ (deps build.sh.in)
+ (mode fallback)
+ (action
+  (run opam config subst "build.sh")))


### PR DESCRIPTION
Make use of opam substitution feature to figure out the correct `jobs` variables to pass on `make`.