### PR TITLE
Silence gmp build

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -10,8 +10,11 @@
  (targets gmp.h libgmp.a dllgmp.so)
  (deps gmp-6.2.1.tar.xz build.sh)
  (action
-  (run sh ./build.sh %{ocaml-config:c_compiler} %{ocaml-config:host}
-    "%{ocaml-config:ocamlc_cflags}" %{ocaml-config:supports_shared_libraries})))
+  (with-stdout-to
+   build.log
+   (run sh ./build.sh %{ocaml-config:c_compiler} %{ocaml-config:host}
+     "%{ocaml-config:ocamlc_cflags}"
+     %{ocaml-config:supports_shared_libraries}))))
 
 (rule
  (targets build.sh)


### PR DESCRIPTION
Building GMP generates a lot of noise when building it, so it's better to redirect the build output to a log file.