### PR TITLE
Fix for cross-compilation

### DIFF
--- a/src/build.sh.in
+++ b/src/build.sh.in
@@ -4,7 +4,8 @@ set -e
 
 tar -xf gmp-6.2.1.tar.xz
 cd gmp-6.2.1
-sed -i.bak 's/gmp_compile=\(.*\)conftest.c/gmp_compile=\1conftest.c $LIBS/' configure
+sed -i.bak 's/\(gmp_compile=.*conftest.c\)/\1 $LIBS/' configure
+sed -i.bak 's/\(gmp_compile="\($HOST_CC\|$i\|$CC_FOR_BUILD\).*conftest.c\) $LIBS/\1/' configure
 
 if [ "$4" = "false" ]; then
     SHARED_LIBRARY_ARG="--disable-shared"


### PR DESCRIPTION
Some parts of the gmp configuration script expect to find a working host compiler. 

But when doing the tests, it would add `-lnolibc -lopenlibm` on the command line thanks the `sed` script, thus breaking the configuration. It's not clear why it worked with x86 ocaml-freestanding, but it's breaking on ARM64. 

mirage-skeleton CI (https://github.com/mirage/mirage-dev/pull/365) says it's okay now