### PR TITLE
use sed -i -e to fix compilation on FreeBSD, also avoid nested or pattern #14

### DIFF
--- a/src/build.sh.in
+++ b/src/build.sh.in
@@ -4,8 +4,8 @@ set -e
 
 tar -xf gmp-6.2.1.tar.xz
 cd gmp-6.2.1
-sed -i.bak 's/\(gmp_compile=.*conftest.c\)/\1 $LIBS/' configure
-sed -i.bak 's/\(gmp_compile="\($HOST_CC\|$i\|$CC_FOR_BUILD\).*conftest.c\) $LIBS/\1/' configure
+sed -i -e 's/\(gmp_compile="$cc .*conftest.c\)/\1 $LIBS/g' configure
+sed -i -e 's/\(gmp_compile="$CC .*conftest.c\)/\1 $LIBS/g' configure
 
 if [ "$4" = "false" ]; then
     SHARED_LIBRARY_ARG="--disable-shared"


### PR DESCRIPTION
I tested this on both FreeBSD and GNU/Linux, and it works fine. This fixes #14. /cc @TheLortex