### PR TITLE
remove opam dependancy

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -23,8 +23,9 @@
      "%{ocaml-config:native_c_libraries}"))))
 
 (rule
- (targets build.sh)
+ (target build.sh)
  (deps build.sh.in)
  (mode fallback)
  (action
-  (run opam config subst "build.sh")))
+  (bash
+    "CORES=`(which nproc > /dev/null 2>&1 && nproc) || sysctl -n hw.ncpu 2> /dev/null || echo 1`; sed \"s/\%{jobs}%/$CORES/g\" %{target}.in > %{target}")))


### PR DESCRIPTION
if the `opam config subst` call fails, substitute the jobs variable with the number of physical cores in the machine