### PR TITLE
Fix cross-compilation of ocaml-gmp with aarch64

### DIFF
--- a/src/build.sh.in
+++ b/src/build.sh.in
@@ -7,22 +7,32 @@ cd gmp-6.2.1
 sed -i -e 's/\(gmp_compile="$cc .*conftest.c\)/\1 $LIBS/g' configure
 sed -i -e 's/\(gmp_compile="$CC .*conftest.c\)/\1 $LIBS/g' configure
 
-if [ "$4" = "false" ]; then
+if [ "$5" = "false" ]; then
     SHARED_LIBRARY_ARG="--disable-shared"
 fi
 
+# $1 => c_compiler
+# $2 => host
+# $3 => target
+# $4 => ocamlc_cflags
+# $5 => supports_shared_libraries
+# $6 => native_c_libraries
+
+echo "ac_cv_func_obstack_vprintf=no ac_cv_func_localeconv=no ./configure --host='$3' --build='$2' CC='$1' CPPFLAGS='$4' LIBS='$6' $SHARED_LIBRARY_ARG"
+echo "make SUBDIRS='mpn mpz mpq mpf' PRINTF_OBJECTS= SCANF_OBJECTS CFLAGS+='-Werror=implicit-function-declaration' CPPFLAGS='$3'"
+
 ac_cv_func_obstack_vprintf=no \
 ac_cv_func_localeconv=no \
-./configure --host="$2" CC="$1" CPPFLAGS="$3" LIBS="$5" $SHARED_LIBRARY_ARG
+./configure --host="$3" --build="$2" CC="$1" CPPFLAGS="$4" LIBS="$6" $SHARED_LIBRARY_ARG
 
 make SUBDIRS="mpn mpz mpq mpf"\
     -j%{jobs}% \
     PRINTF_OBJECTS= SCANF_OBJECTS= \
-    CFLAGS+="-Werror=implicit-function-declaration" CPPFLAGS="$3"
+    CFLAGS+="-Werror=implicit-function-declaration" CPPFLAGS="$4"
 
 cp gmp.h ..
 cp .libs/libgmp.a ..
-if [ "$4" = "true" ]; then
+if [ "$5" = "true" ]; then
     # depending on if the host is macos or not
     cp .libs/libgmp.so ../dllgmp.so || cp .libs/libgmp.dylib ../dllgmp.so 
 else

--- a/src/dune
+++ b/src/dune
@@ -17,7 +17,9 @@
  (action
   (with-stdout-to
    build.log
-   (run sh ./build.sh "%{ocaml-config:c_compiler}" "%{ocaml-config:host}"
+   (run sh ./build.sh "%{ocaml-config:c_compiler}"
+     "%{ocaml-config:host}"
+     "%{ocaml-config:target}"
      "%{ocaml-config:ocamlc_cflags}"
      %{ocaml-config:supports_shared_libraries}
      "%{ocaml-config:native_c_libraries}"))))


### PR DESCRIPTION
If we really want to cross-compile `gmp` on `aarch64`, we need to specify `--host` as the `ocamlc -config|grep target|cut -d' ' -f2` (and not the `host` value from the `ocamlc -config`). The `./configure` say:
```
 System types:
   --build=BUILD     configure for building on BUILD [guessed]
   --host=HOST       cross-compile to build programs to run on HOST [BUILD]
```

So, `--host` corresponds to the target and `--build` correspond to the host's compiler. It's a bit confusing but this patch seems on the right direction. We need to test it with `ocaml-solo5`, I suspect that `ocaml-solo5` does not set properly its `target` value.