### PR TITLE
Install a relocatable gmp.pc

### DIFF
--- a/gmp.opam
+++ b/gmp.opam
@@ -5,7 +5,7 @@ authors: "Torbjörn Granlund and contributors"
 homepage: "https://github.com/mirage/ocaml-gmp"
 bug-reports: "https://github.com/mirage/ocaml-gmp/issues"
 dev-repo: "git+https://github.com/mirage/ocaml-gmp.git"
-substs: [ "src/build.sh" ]
+substs: [ "src/build.sh" "src/gmp.pc" ]
 build: [
  [ "dune" "build" "-p" name "-j" jobs ]
  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}

--- a/src/dune
+++ b/src/dune
@@ -11,6 +11,11 @@
   (dllgmp.so as libgmp.so))
  (section lib))
 
+(install
+ (section lib_root)
+ (files
+  (gmp.pc as pkgconfig/gmp.pc)))
+
 (rule
  (targets gmp.h libgmp.a dllgmp.so)
  (deps gmp-6.3.0.tar.xz build.sh gcc.15.patch)
@@ -29,3 +34,10 @@
  (action
   (bash
     "CORES=`(which nproc > /dev/null 2>&1 && nproc) || sysctl -n hw.ncpu 2> /dev/null || echo 1`; sed \"s/\%{jobs}%/$CORES/g\" %{target}.in > %{target}")))
+
+(rule
+ (target gmp.pc)
+ (deps gmp.pc.in)
+ (mode fallback)
+ (action
+  (bash "sed \"s/\%{version}%/6.3.0/g\" %{target}.in > %{target}")))

--- a/src/gmp.pc.in
+++ b/src/gmp.pc.in
@@ -1,0 +1,9 @@
+prefix=${pcfiledir}/../gmp
+includedir=${prefix}
+libdir=${prefix}
+
+Name: GMP
+Description: GNU Multiple Precision Arithmetic Library
+Version: %{version}%
+Libs: -L${libdir} -lgmp
+Cflags: -I${includedir}


### PR DESCRIPTION
Consumers that find GMP through `pkg-config gmp` (e.g. zarith's configure) get nothing today: this package ships `gmp.h` and `libgmp.a`, but no `.pc` file.

This PR installs a relocatable `gmp.pc` under `lib/pkgconfig`. The prefix uses `${pcfiledir}`, so it resolves from any install location, including a cross sysroot, without baking an absolute `-L` path.

Stacked on #31 (the cross CI bump); the diff here is only the `gmp.pc` install.

The rest of the macOS unikernel stack:
- Solo5/solo5#641 builds the aarch64 cross toolchain on macOS
- mirage/ocaml-solo5#171 builds the aarch64 cross-compiler on macOS
- ocaml/Zarith#173 honours the `OCAML*` environment variables in configure
- mirage/ocaml-gmp#30 archives `libgmp.a` with the cross `ar`/`ranlib`

