### PR TITLE
Archive libgmp.a with the cross ar/ranlib when cross-compiling

### DIFF
--- a/src/build.sh.in
+++ b/src/build.sh.in
@@ -23,9 +23,20 @@ fi
 # $5 => supports_shared_libraries
 # $6 => native_c_libraries
 
+# Cross ar/ranlib from the C compiler prefix: the build machine's tools on macOS
+# write a Mach-O symbol table over the ELF members, so libgmp.a links as empty.
+cc_prog=${1%% *}
+tool_prefix=${cc_prog%-*}
+if [ "$tool_prefix" != "$cc_prog" ] && command -v "${tool_prefix}-ar" >/dev/null 2>&1; then
+    CROSS_AR="AR=${tool_prefix}-ar"
+    if command -v "${tool_prefix}-ranlib" >/dev/null 2>&1; then
+        CROSS_RANLIB="RANLIB=${tool_prefix}-ranlib"
+    fi
+fi
+
 ac_cv_func_obstack_vprintf=no \
 ac_cv_func_localeconv=no \
-./configure --host="$3" --build="$2" ABI=64 CC="$1" CPPFLAGS="$4" LIBS="$6" $SHARED_LIBRARY_ARG
+./configure --host="$3" --build="$2" ABI=64 CC="$1" $CROSS_AR $CROSS_RANLIB CPPFLAGS="$4" LIBS="$6" $SHARED_LIBRARY_ARG
 
 make SUBDIRS="mpn mpz mpq mpf"\
     -j%{jobs}% \


### PR DESCRIPTION
Cross-compiling on a macOS host, `configure` runs with `--host` set to the OCaml target triple, for which no `ar`/`ranlib` exists, so autotools falls back to the build machine's. On macOS those write a Mach-O symbol table over the ELF member objects, and the cross linker then reads `libgmp.a` as empty (undefined `__gmpn_*` at link).

This PR derives the toolchain's `ar`/`ranlib` from the C-compiler prefix and passes them to `configure`. Native builds are unchanged.

Stacked on #31 (the cross CI bump); the diff here is only the `ar`/`ranlib` change.

Part of the macOS unikernel stack:
- Solo5/solo5#641 builds the aarch64 cross toolchain on macOS
- mirage/ocaml-solo5#171 builds the aarch64 cross-compiler on macOS
- mirage/ocaml-gmp#29 installs a relocatable `gmp.pc`
- ocaml/Zarith#173 honours the `OCAML*` environment variables in configure

