### PR TITLE
Bump the Solo5 cross job to OCaml 5.4.1

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        ocaml-version: [5.3.0]
+        ocaml-version: [5.4.1]
     runs-on: ${{ matrix.operating-system }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
`ocaml-solo5` now requires `ocaml = 5.4.1`, so the `Cross-Solo5` job no longer resolves on 5.3.0:

```
[ERROR] No solution for ocaml-solo5:
  - (invariant) → ocaml-base-compiler = 5.3.0
  - ocaml-solo5 → ocaml = 5.4.1 → ocaml-base-compiler >= 5.4.1~
```

This PR bumps the job to 5.4.1. It unblocks the cross CI for #29 and #30.
